### PR TITLE
feat: add pinning service support

### DIFF
--- a/get.go
+++ b/get.go
@@ -16,6 +16,6 @@ func (c *client) Get(ctx context.Context, cid cid.Cid) (*w3http.Web3Response, er
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.cfg.token))
 	req.Header.Add("X-Client", clientName)
-	res, err := c.hc.Do(req)
+	res, err := c.cfg.hc.Do(req)
 	return w3http.NewWeb3Response(res, c.bsvc), err
 }

--- a/get_test.go
+++ b/get_test.go
@@ -1,0 +1,137 @@
+package w3s
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+)
+
+const (
+	validToken = "validtoken"
+
+	// a car containing a single file called helloword.txt
+	helloRoot   = "bafybeicymili4gmgoa4xpx5jfghi7leffvai4fd47f6nxgrhq4ug6ekiga"
+	helloCarHex = "3aa265726f6f747381d82a582500017012205862168e1986703977dfa9298e8fac852d408e147cf97cdb9a2787286f1148306776657273696f6e0162017012205862168e1986703977dfa9298e8fac852d408e147cf97cdb9a2787286f11483012380a2401551220315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3120e68656c6c6f776f726c642e747874180d0a0208013101551220315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd348656c6c6f2c20776f726c6421"
+
+	// a car containing a single file called thanks.txt
+	thanksRoot   = "bafybeid7orcaehmy2lzlkr4wnfgexmm2xoonmamaimdsjycex7wu4pjip4"
+	thanksCarHex = "3aa265726f6f747381d82a582500017012207f7444021d98d2f2b54796694c4bb19abb9cd60180430724e044bfed4e3d287f6776657273696f6e015e017012207f7444021d98d2f2b54796694c4bb19abb9cd60180430724e044bfed4e3d287f12340a24015512200386a02a5f79b12d40569f36f0e3623d71f6655d00c5c0fc3826b4a945670685120a7468616e6b732e74787418170a0208013b015512200386a02a5f79b12d40569f36f0e3623d71f6655d00c5c0fc3826b4a9456706855468616e6b7320666f7220616c6c207468652066697368"
+)
+
+type routeMap map[string]map[string]http.HandlerFunc
+
+func startTestServer(t *testing.T, routes routeMap) (*http.Client, func()) {
+	mux := http.NewServeMux()
+	for path, methodHandlers := range routes {
+		for method, handler := range methodHandlers {
+			mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != method {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				handler(w, r)
+			})
+		}
+	}
+
+	ts := httptest.NewServer(mux)
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to parse httptest.Server URL: %v", err)
+	}
+
+	hc := &http.Client{
+		Transport: urlRewriteTransport{URL: u},
+	}
+
+	return hc, func() {
+		ts.Close()
+	}
+}
+
+type urlRewriteTransport struct {
+	Transport http.RoundTripper
+	URL       *url.URL
+}
+
+func (t urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.URL.Scheme
+	req.URL.Host = t.URL.Host
+	req.URL.Path = path.Join(t.URL.Path, req.URL.Path)
+	rt := t.Transport
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	return rt.RoundTrip(req)
+}
+
+var getHelloCarHandler = func(w http.ResponseWriter, r *http.Request) {
+	carbytes, err := hex.DecodeString(helloCarHex)
+	if err != nil {
+		fmt.Printf("DecodeString: %v\n", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/car")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+helloRoot+`.car"`)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(carbytes)
+}
+
+func TestGetHappyPath(t *testing.T) {
+	routes := routeMap{
+		"/car/" + helloRoot: {
+			http.MethodGet: getHelloCarHandler,
+		},
+	}
+
+	hc, cleanup := startTestServer(t, routes)
+	defer cleanup()
+
+	client, err := NewClient(WithHTTPClient(hc), WithToken("validtoken"))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	c, _ := cid.Parse(helloRoot)
+	resp, err := client.Get(context.Background(), c)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("got status %d, wanted %d", resp.StatusCode, 200)
+	}
+
+	f, fsys, err := resp.Files()
+	if err != nil {
+		t.Fatalf("failed to read files: %v", err)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("failed to send stat car: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Fatalf("expected a car containing a directory of files")
+	}
+	err = fs.WalkDir(fsys, "/", func(path string, d fs.DirEntry, werr error) error {
+		_, err := d.Info()
+		return err
+	})
+	if err != nil {
+		t.Fatalf("failed to send walk car: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,5 +24,6 @@ require (
 	github.com/ipld/go-codec-dagpb v1.3.0
 	github.com/ipld/go-ipld-prime v0.14.3
 	github.com/libp2p/go-libp2p-core v0.11.0
+	github.com/multiformats/go-multiaddr v0.4.1
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 )

--- a/list.go
+++ b/list.go
@@ -73,7 +73,7 @@ func (c *client) List(ctx context.Context, options ...ListOption) (*UploadIterat
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.cfg.token))
 		req.Header.Add("Access-Control-Request-Headers", "Link")
 		req.Header.Add("X-Client", clientName)
-		res, err := c.hc.Do(req)
+		res, err := c.cfg.hc.Do(req)
 		if err != nil {
 			return nil, err
 		}

--- a/pin.go
+++ b/pin.go
@@ -1,0 +1,197 @@
+package w3s
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ipfs/go-cid"
+)
+
+type PinResponse struct {
+	RequestID string
+	Status    string
+	Created   time.Time
+	Pin       PinResponseDetail
+	Delegates []string
+}
+
+type pinResponseJson struct {
+	RequestID string            `json:"requestId"`
+	Status    string            `json:"status"`
+	Created   string            `json:"created"`
+	Pin       PinResponseDetail `json:"pin"`
+	Delegates []string          `json:"delegates"`
+}
+
+func (p *PinResponse) UnmarshalJSON(b []byte) error {
+	var raw pinResponseJson
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+	p.RequestID = raw.RequestID
+	p.Status = raw.Status
+	if raw.Created != "" {
+		p.Created, err = time.Parse(iso8601, raw.Created)
+		if err != nil {
+			return err
+		}
+	}
+	p.Pin = raw.Pin
+	p.Delegates = raw.Delegates
+
+	return nil
+}
+
+type PinResponseDetail struct {
+	Cid        cid.Cid
+	SourceCid  cid.Cid
+	ContentCid cid.Cid
+	Name       string
+	Origins    []string
+	Meta       map[string]string
+	Deleted    time.Time
+	Created    time.Time
+	Updated    time.Time
+	Pins       []Pin
+}
+
+type pinResponseDetailJson struct {
+	Cid        string            `json:"cid"`
+	SourceCid  string            `json:"sourceCid"`
+	ContentCid string            `json:"contentCid"`
+	Name       string            `json:"name"`
+	Origins    []string          `json:"origins,omitempty"`
+	Meta       map[string]string `json:"meta,omitempty"`
+	Deleted    string            `json:"deleted,omitempty"`
+	Created    string            `json:"created,omitempty"`
+	Updated    string            `json:"updated,omitempty"`
+	Pins       []Pin             `json:"pins,omitempty"`
+}
+
+func (p *PinResponseDetail) UnmarshalJSON(b []byte) error {
+	var raw pinResponseDetailJson
+	err := json.Unmarshal(b, &raw)
+	if err != nil {
+		return err
+	}
+
+	if raw.Cid != "" {
+		p.Cid, err = cid.Parse(raw.Cid)
+		if err != nil {
+			return err
+		}
+	} else {
+		p.Cid = cid.Undef
+	}
+
+	if raw.SourceCid != "" {
+		p.SourceCid, err = cid.Parse(raw.SourceCid)
+		if err != nil {
+			return err
+		}
+	} else {
+		p.SourceCid = cid.Undef
+	}
+
+	if raw.ContentCid != "" {
+		p.ContentCid, err = cid.Parse(raw.ContentCid)
+		if err != nil {
+			return err
+		}
+	} else {
+		p.ContentCid = cid.Undef
+	}
+
+	p.Name = raw.Name
+	p.Origins = raw.Origins
+	p.Meta = raw.Meta
+
+	if raw.Deleted != "" {
+		p.Deleted, err = time.Parse(iso8601, raw.Deleted)
+		if err != nil {
+			return err
+		}
+	}
+
+	if raw.Created != "" {
+		p.Created, err = time.Parse(iso8601, raw.Created)
+		if err != nil {
+			return err
+		}
+	}
+
+	if raw.Updated != "" {
+		p.Updated, err = time.Parse(iso8601, raw.Updated)
+		if err != nil {
+			return err
+		}
+	}
+
+	p.Pins = raw.Pins
+
+	return nil
+}
+
+type pinConfig struct {
+	name    string
+	origins []string
+	meta    map[string]string
+}
+
+// Pin adds a new pin to Web3.Storage.
+func (c *client) Pin(ctx context.Context, cid cid.Cid, options ...PinOption) (*PinResponse, error) {
+	var cfg pinConfig
+	for _, opt := range options {
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	pinData := struct {
+		Cid     string            `json:"cid"`
+		Name    string            `json:"name,omitempty"`
+		Origins []string          `json:"origins,omitempty"`
+		Meta    map[string]string `json:"meta,omitempty"`
+	}{
+		Cid:     cid.String(),
+		Name:    cfg.name,
+		Origins: cfg.origins,
+		Meta:    cfg.meta,
+	}
+
+	encoded := new(bytes.Buffer)
+	err := json.NewEncoder(encoded).Encode(&pinData)
+	if err != nil {
+		return nil, fmt.Errorf("encode pin request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/pins", c.cfg.endpoint), encoded)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.cfg.token))
+	req.Header.Add("X-Client", clientName)
+	res, err := c.cfg.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send pin request: %w", err)
+	}
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected response status: %d", res.StatusCode)
+	}
+	defer res.Body.Close()
+
+	d := json.NewDecoder(res.Body)
+
+	var pr PinResponse
+	err = d.Decode(&pr)
+	if err != nil {
+		return nil, fmt.Errorf("decode pin response: %w", err)
+	}
+	return &pr, nil
+}

--- a/pin_test.go
+++ b/pin_test.go
@@ -1,0 +1,69 @@
+package w3s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+)
+
+var pinsHandler = func(w http.ResponseWriter, r *http.Request) {
+	if !hasValidToken(w, r) {
+		return
+	}
+
+	body := map[string]interface{}{}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		fmt.Printf("json decode: %v\n", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+
+	}
+
+	fmt.Printf("body: %+v\n", body)
+
+	resp := map[string]interface{}{
+		"requestId": fmt.Sprintf("pin-%s", body["cid"]),
+		"status":    "pinned",
+		"created":   "2022-02-20T15:04:05.999Z",
+		"pin": map[string]interface{}{
+			"cid": body["cid"],
+		},
+		"delegates": []interface{}{},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
+}
+
+func TestPinsHappyPath(t *testing.T) {
+	routes := routeMap{
+		"/pins": {
+			http.MethodPost: pinsHandler,
+		},
+	}
+
+	hc, cleanup := startTestServer(t, routes)
+	defer cleanup()
+
+	client, err := NewClient(WithHTTPClient(hc), WithToken("validtoken"))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	c, _ := cid.Parse(helloRoot)
+
+	pr, err := client.Pin(context.Background(), c)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	if pr.Pin.Cid.String() != helloRoot {
+		t.Fatalf("got cid %s, wanted %s", pr.Pin.Cid.String(), helloRoot)
+	}
+}

--- a/put.go
+++ b/put.go
@@ -68,8 +68,6 @@ func (c *client) Put(ctx context.Context, file fs.File, options ...PutOption) (c
 		root = cnode.Cid()
 	}
 
-	// fmt.Println("root CID", root)
-
 	carReader, carWriter := io.Pipe()
 
 	go func() {
@@ -121,7 +119,7 @@ func (c *client) sendCar(ctx context.Context, r io.Reader) (cid.Cid, error) {
 	req.Header.Add("Content-Type", "application/car")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.cfg.token))
 	req.Header.Add("X-Client", clientName)
-	res, err := c.hc.Do(req)
+	res, err := c.cfg.hc.Do(req)
 	if err != nil {
 		return cid.Undef, err
 	}

--- a/put_test.go
+++ b/put_test.go
@@ -1,0 +1,75 @@
+package w3s
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ipld/go-car"
+)
+
+func hasValidToken(w http.ResponseWriter, r *http.Request) bool {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer "+validToken {
+		w.WriteHeader(http.StatusUnauthorized)
+		return false
+	}
+
+	return true
+}
+
+var putCarHandler = func(w http.ResponseWriter, r *http.Request) {
+	if !hasValidToken(w, r) {
+		return
+	}
+
+	cr, err := car.NewCarReader(r.Body)
+	if err != nil {
+		fmt.Printf("NewCarReader: %v\n", err)
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	rootCid := cr.Header.Roots[0]
+
+	w.WriteHeader(http.StatusOK)
+	var out struct {
+		Cid string `json:"cid"`
+	}
+	out.Cid = rootCid.String()
+
+	json.NewEncoder(w).Encode(out)
+}
+
+func TestPutCarHappyPath(t *testing.T) {
+	routes := routeMap{
+		"/car": {
+			http.MethodPost: putCarHandler,
+		},
+	}
+
+	hc, cleanup := startTestServer(t, routes)
+	defer cleanup()
+
+	client, err := NewClient(WithHTTPClient(hc), WithToken("validtoken"))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	carbytes, err := hex.DecodeString(helloCarHex)
+	if err != nil {
+		t.Fatalf("failed to decode car hex: %v", err)
+		return
+	}
+
+	c, err := client.PutCar(context.Background(), bytes.NewReader(carbytes))
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	if c.String() != helloRoot {
+		t.Fatalf("got cid %s, wanted %s", c.String(), helloRoot)
+	}
+}

--- a/status.go
+++ b/status.go
@@ -21,6 +21,9 @@ const (
 	PinStatusPinned    = PinStatus(api.TrackerStatusPinned)
 	PinStatusPinning   = PinStatus(api.TrackerStatusPinning)
 	PinStatusPinQueued = PinStatus(api.TrackerStatusPinQueued)
+	PinStatusRemote    = PinStatus(api.TrackerStatusRemote)
+	PinStatusUnpinned  = PinStatus(api.TrackerStatusUnpinned)
+	PinStatusUnknown   = PinStatus(-1)
 )
 
 func (s PinStatus) String() string {
@@ -32,6 +35,12 @@ func (s PinStatus) String() string {
 	}
 	if s == PinStatusPinQueued {
 		return "PinQueued"
+	}
+	if s == PinStatusRemote {
+		return "Remote"
+	}
+	if s == PinStatusUnpinned {
+		return "Unpinned"
 	}
 	return "Unknown"
 }
@@ -70,8 +79,12 @@ func (p *Pin) UnmarshalJSON(b []byte) error {
 		p.Status = PinStatusPinning
 	} else if raw.Status == "PinQueued" {
 		p.Status = PinStatusPinQueued
+	} else if raw.Status == "Remote" {
+		p.Status = PinStatusRemote
+	} else if raw.Status == "Unpinned" {
+		p.Status = PinStatusUnpinned
 	} else {
-		return fmt.Errorf("unknown pin status: %s", raw.Status)
+		p.Status = PinStatusUnknown
 	}
 	return nil
 }
@@ -210,7 +223,7 @@ func (c *client) Status(ctx context.Context, cid cid.Cid) (*Status, error) {
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.cfg.token))
 	req.Header.Add("X-Client", clientName)
-	res, err := c.hc.Do(req)
+	res, err := c.cfg.hc.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,65 @@
+package w3s
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+)
+
+var statusHelloCarHandler = func(w http.ResponseWriter, r *http.Request) {
+	carbytes, err := hex.DecodeString(helloCarHex)
+	if err != nil {
+		fmt.Printf("DecodeString: %v\n", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	status := map[string]interface{}{
+		"cid":     helloRoot,
+		"dagSize": len(carbytes),
+		"created": "2022-02-20T15:04:05.999Z",
+		"pins":    []interface{}{},
+		"deals":   []interface{}{},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(status)
+}
+
+func TestStatusHappyPath(t *testing.T) {
+	routes := routeMap{
+		"/status/" + helloRoot: {
+			http.MethodGet: statusHelloCarHandler,
+		},
+	}
+
+	hc, cleanup := startTestServer(t, routes)
+	defer cleanup()
+
+	client, err := NewClient(WithHTTPClient(hc), WithToken("validtoken"))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	c, _ := cid.Parse(helloRoot)
+
+	st, err := client.Status(context.Background(), c)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	if st.Cid.String() != helloRoot {
+		t.Fatalf("got cid %s, wanted %s", st.Cid.String(), helloRoot)
+	}
+
+	if st.DagSize != 208 {
+		t.Fatalf("got dagsize %d, wanted %d", st.DagSize, 208)
+	}
+}


### PR DESCRIPTION
Initial support for pinning service API. Adds a new client method `Pin` which pins a cid. 

Also adds a number of simple happy path tests for client methods, which can be built on to cover more cases.