### PR TITLE
fix: return first page of list results even if Link header is missing

### DIFF
--- a/list.go
+++ b/list.go
@@ -121,20 +121,23 @@ func newPageIterator(url string, fetchNextPage func(string) (*http.Response, err
 }
 
 func (pi *pageIterator) Next() (*http.Response, error) {
+	if pi.nextURL == "" {
+		return nil, io.EOF
+	}
 	res, err := pi.fetchNextPage(pi.nextURL)
 	if err != nil {
 		return nil, err
 	}
 	linkHdrs := res.Header["Link"]
-	if len(linkHdrs) == 0 {
-		return nil, io.EOF
-	}
-	links := linkheader.Parse(linkHdrs[0])
-	for _, l := range links {
-		if l.Rel == "next" {
-			pi.nextURL = links[0].URL
-			return res, nil
+	pi.nextURL = ""
+	if len(linkHdrs) > 0 {
+		links := linkheader.Parse(linkHdrs[0])
+		for _, l := range links {
+			if l.Rel == "next" {
+				pi.nextURL = l.URL
+				break
+			}
 		}
 	}
-	return nil, io.EOF
+	return res, nil
 }


### PR DESCRIPTION
This fixes #19 by making sure the `pageIterator` always returns the first page of results, even if it doesn't have a `Link` header. The API only sends the header if you have more than one page of results, so list was broken if you had less than a page.